### PR TITLE
feat: configuracao do banco de dados InfluxDB e backend receptor UDP

### DIFF
--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install --omit=dev
+
+COPY . .
+
+EXPOSE 41234/udp
+
+CMD ["node", "index.js"]

--- a/src/backend/docker-compose.yml
+++ b/src/backend/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: micromouse_influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=123
+      - DOCKER_INFLUXDB_INIT_ORG=micromouse
+      - DOCKER_INFLUXDB_INIT_BUCKET=micromouse_telemetria
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=micromouse-token-12345
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build: .
+    container_name: micromouse_backend
+    ports:
+      - "41234:41234/udp"
+    environment:
+      - UDP_PORT=41234
+      - UDP_HOST=0.0.0.0
+      - INFLUX_URL=http://influxdb:8086
+      - INFLUX_TOKEN=micromouse-token-12345
+      - INFLUX_ORG=micromouse
+      - INFLUX_BUCKET=micromouse_telemetria
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  influxdb-data:
+  influxdb-config:

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,0 +1,146 @@
+import dgram from 'node:dgram';
+import { decode } from '@msgpack/msgpack';
+import { InfluxDB, Point } from '@influxdata/influxdb-client';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const UDP_PORT = process.env.UDP_PORT ? parseInt(process.env.UDP_PORT, 10) : 41234;
+const UDP_HOST = process.env.UDP_HOST || '0.0.0.0';
+
+const INFLUX_URL = process.env.INFLUX_URL || 'http://localhost:8086';
+const INFLUX_TOKEN = process.env.INFLUX_TOKEN || 'micromouse-token-12345';
+const INFLUX_ORG = process.env.INFLUX_ORG || 'micromouse';
+const INFLUX_BUCKET = process.env.INFLUX_BUCKET || 'micromouse_telemetria';
+
+console.log('--- CONFIGURAÇÃO DO BACKEND ---');
+console.log(`Porta UDP: ${UDP_PORT}`);
+console.log(`Endereço UDP: ${UDP_HOST}`);
+console.log(`InfluxDB URL: ${INFLUX_URL}`);
+console.log(`InfluxDB Org: ${INFLUX_ORG}`);
+console.log(`InfluxDB Bucket: ${INFLUX_BUCKET}`);
+console.log('--------------------------------');
+
+// Inicializa cliente InfluxDB
+const influxDB = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
+const writeApi = influxDB.getWriteApi(INFLUX_ORG, INFLUX_BUCKET, 'ns');
+
+// Cria servidor UDP
+const server = dgram.createSocket('udp4');
+
+server.on('listening', () => {
+  const address = server.address();
+  console.log(`[UDP] Servidor escutando em ${address.address}:${address.port}`);
+});
+
+server.on('message', (msg, rinfo) => {
+  try {
+    // Decodifica o payload recebido via MsgPack
+    const data = decode(msg);
+    console.log(`[UDP] Recebido de ${rinfo.address}:${rinfo.port}:`, data);
+
+    // Mapeamento dinâmico e seguro para o esquema InfluxDB
+    const estado_robo = data.estado_fsm || data.estado_robo || 'IDLE';
+    const id_labirinto = data.id_labirinto || 'default';
+    const id_corrida = data.id_corrida || 'default';
+    const objetivo = data.objetivo || 'N';
+
+    const point = new Point('log_corrida')
+      .tag('id_labirinto', id_labirinto)
+      .tag('id_corrida', id_corrida)
+      .tag('objetivo', objetivo)
+      .tag('estado_robo', estado_robo);
+
+    // Campos (Fields) numéricos ou strings
+    const floatFields = {
+      bateria: data.bateria_v !== undefined ? data.bateria_v : data.bateria,
+      erro_pid: data.erro_pid,
+      velocidade_media: data.velocidade_media
+    };
+
+    const intFields = {
+      pos_x: data.posicao_x !== undefined ? data.posicao_x : data.pos_x,
+      pos_y: data.posicao_y !== undefined ? data.posicao_y : data.pos_y,
+      dist_frontal: data.dist_frontal,
+      dist_esq: data.dist_esq,
+      dist_dir: data.dist_dir,
+      pwm_esq: data.pwm_esq,
+      pwm_dir: data.pwm_dir
+    };
+
+    const stringFields = {
+      orientacao: data.orientacao
+    };
+
+    // Adiciona Fields Float
+    for (const [key, val] of Object.entries(floatFields)) {
+      if (val !== undefined && val !== null) {
+        point.floatField(key, parseFloat(val));
+      }
+    }
+
+    // Adiciona Fields Int
+    for (const [key, val] of Object.entries(intFields)) {
+      if (val !== undefined && val !== null) {
+        point.intField(key, parseInt(val, 10));
+      }
+    }
+
+    // Adiciona Fields String
+    for (const [key, val] of Object.entries(stringFields)) {
+      if (val !== undefined && val !== null) {
+        point.stringField(key, String(val));
+      }
+    }
+
+    // Define timestamp (se vier em segundos Unix, converte para ns)
+    if (data.timestamp) {
+      const tsMs = data.timestamp < 9999999999 ? data.timestamp * 1000 : data.timestamp;
+      point.timestamp(new Date(tsMs));
+    } else {
+      point.timestamp(new Date()); // Se não tiver, usa hora atual do servidor
+    }
+
+    // Grava ponto no InfluxDB
+    writeApi.writePoint(point);
+    
+    // Tenta flush para persistência imediata (útil para desenvolvimento)
+    writeApi.flush()
+      .then(() => {
+        console.log(`[InfluxDB] Ponto gravado com sucesso no bucket: ${INFLUX_BUCKET}`);
+      })
+      .catch((err) => {
+        console.error('[InfluxDB] Erro ao gravar ponto:', err.message);
+      });
+
+  } catch (err) {
+    console.error('[UDP] Erro ao processar mensagem ou decodificar MsgPack:', err.message);
+  }
+});
+
+server.on('error', (err) => {
+  console.error(`[UDP] Erro no servidor: ${err.message}`);
+  server.close();
+});
+
+// Inicia escuta
+server.bind(UDP_PORT, UDP_HOST);
+
+// Encerramento limpo
+const shutdown = () => {
+  console.log('Encerrando servidor...');
+  server.close(() => {
+    writeApi.close()
+      .then(() => {
+        console.log('Conexões com InfluxDB encerradas.');
+        process.exit(0);
+      })
+      .catch((err) => {
+        console.error('Erro ao fechar conexão com InfluxDB:', err);
+        process.exit(1);
+      });
+  });
+};
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/src/backend/mock_sender.js
+++ b/src/backend/mock_sender.js
@@ -1,0 +1,113 @@
+import dgram from 'node:dgram';
+import { encode } from '@msgpack/msgpack';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const UDP_PORT = process.env.UDP_PORT ? parseInt(process.env.UDP_PORT, 10) : 41234;
+const UDP_HOST = process.env.UDP_HOST || '127.0.0.1';
+
+const client = dgram.createSocket('udp4');
+
+// Definições de corridas diferentes para simular comportamentos variados
+const runs = [
+  {
+    id_corrida: "run_test_01_sucesso",
+    id_labirinto: "16x16_standard",
+    stream: [
+      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.0, dist_frontal: 150 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.38, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.05, dist_frontal: 140 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.35, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.02, dist_frontal: 130 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.33, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.08, dist_frontal: 120 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.31, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.04, dist_frontal: 110 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.28, posicao_x: 2, posicao_y: 3, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 100 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.25, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.03, dist_frontal: 90 },
+      { estado_fsm: "GOAL_REACHED", bateria_v: 7.22, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.00, dist_frontal: 80 }
+    ]
+  },
+  {
+    id_corrida: "run_test_02_falha_bateria",
+    id_labirinto: "16x16_standard",
+    stream: [
+      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.0, dist_frontal: 150 },
+      { estado_fsm: "MAPPING",     bateria_v: 7.10, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.04, dist_frontal: 140 },
+      { estado_fsm: "MAPPING",     bateria_v: 6.80, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.05, dist_frontal: 130 },
+      { estado_fsm: "MAPPING",     bateria_v: 6.20, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.12, dist_frontal: 120 },
+      { estado_fsm: "ERROR",       bateria_v: 5.75, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.00, dist_frontal: 120 },
+      { estado_fsm: "ERROR",       bateria_v: 5.50, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.00, dist_frontal: 120 }
+    ]
+  },
+  {
+    id_corrida: "run_test_03_fast_run",
+    id_labirinto: "16x16_standard",
+    stream: [
+      { estado_fsm: "FAST_RUN", bateria_v: 7.30, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 150 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.27, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.02, dist_frontal: 140 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.24, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.01, dist_frontal: 130 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.21, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.03, dist_frontal: 120 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.18, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.02, dist_frontal: 110 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.14, posicao_x: 2, posicao_y: 3, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 100 },
+      { estado_fsm: "FAST_RUN", bateria_v: 7.10, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.02, dist_frontal: 90 }
+    ]
+  }
+];
+
+let activeRunIndex = 0;
+let currentStepIndex = 0;
+
+function sendTelemetry() {
+  const currentRun = runs[activeRunIndex];
+  const stepData = currentRun.stream[currentStepIndex];
+
+  // Adiciona campos calculados/metadados dinâmicos
+  const isFastRun = stepData.estado_fsm === "FAST_RUN";
+  const fullTelemetry = {
+    ...stepData,
+    timestamp: Math.floor(Date.now() / 1000),
+    id_corrida: currentRun.id_corrida,
+    id_labirinto: currentRun.id_labirinto,
+    objetivo: stepData.estado_fsm === "GOAL_REACHED" ? "S" : "N",
+    dist_esq: 85 + Math.floor(Math.sin(currentStepIndex) * 5),
+    dist_dir: 85 - Math.floor(Math.sin(currentStepIndex) * 5),
+    // Simula motores mais rápidos e estáveis no FAST_RUN
+    pwm_esq: isFastRun ? 210 : 120 + Math.floor(Math.random() * 8),
+    pwm_dir: isFastRun ? 212 : 120 + Math.floor(Math.random() * 8),
+    velocidade_media: isFastRun ? 0.85 + (Math.random() * 0.05) : 0.35 + (Math.random() * 0.03)
+  };
+
+  // Codifica em MsgPack
+  const msgBuffer = Buffer.from(encode(fullTelemetry));
+
+  console.log(`[Mock Sender] [${currentRun.id_corrida}] Enviando passo ${currentStepIndex + 1}/${currentRun.stream.length}...`);
+
+  client.send(msgBuffer, 0, msgBuffer.length, UDP_PORT, UDP_HOST, (err) => {
+    if (err) {
+      console.error('[Mock Sender] Erro ao enviar pacote UDP:', err.message);
+    }
+  });
+
+  currentStepIndex++;
+
+  // Se a corrida ativa terminar, passa para a próxima após uma breve pausa no console
+  if (currentStepIndex >= currentRun.stream.length) {
+    console.log(`\n=== FIM DA CORRIDA: ${currentRun.id_corrida} ===`);
+    activeRunIndex = (activeRunIndex + 1) % runs.length;
+    currentStepIndex = 0;
+    console.log(`=== PREPARANDO PRÓXIMA CORRIDA: ${runs[activeRunIndex].id_corrida} ===\n`);
+  }
+}
+
+console.log(`[Mock Sender] Iniciando simulador de telemetria UDP (${UDP_HOST}:${UDP_PORT})...`);
+console.log(`Simulando sequencialmente ${runs.length} tipos de corridas.`);
+console.log('Pressione CTRL+C para parar.\n');
+
+// Envia telemetria a cada 1 segundo
+const interval = setInterval(sendTelemetry, 1000);
+
+process.on('SIGINT', () => {
+  clearInterval(interval);
+  client.close(() => {
+    console.log('[Mock Sender] Encerrado.');
+    process.exit(0);
+  });
+});

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "micromouse-backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "micromouse-backend",
+      "version": "1.0.0",
+      "dependencies": {
+        "@influxdata/influxdb-client": "^1.35.0",
+        "@msgpack/msgpack": "^2.8.0",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "node_modules/@influxdata/influxdb-client": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@influxdata/influxdb-client/-/influxdb-client-1.35.0.tgz",
+      "integrity": "sha512-woWMi8PDpPQpvTsRaUw4Ig+nOGS/CWwAwS66Fa1Vr/EkW+NEwxI8YfPBsdBMn33jK2Y86/qMiiuX/ROHIkJLTw==",
+      "license": "MIT"
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    }
+  }
+}

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "micromouse-backend",
+  "version": "1.0.0",
+  "description": "UDP telemetry listener and InfluxDB writer",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "mock": "node mock_sender.js"
+  },
+  "dependencies": {
+    "@influxdata/influxdb-client": "^1.35.0",
+    "@msgpack/msgpack": "^2.8.0",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
# Descrição do Pull Request

Este PR implementa a infraestrutura do backend para recepção de dados de telemetria do robô via UDP (usando serialização MsgPack) e persistência em banco de dados de séries temporais (InfluxDB v2), totalmente conteinerizado utilizando contêineres Docker.

## O que foi feito

* **HU 4.1 Setup de Banco de Dados e Contrato UDP:**
  * **Banco de Dados (InfluxDB v2):** Configuração automática do banco com a criação da organização `micromouse`, do bucket `micromouse_telemetria` e definição de um token de acesso seguro, persistido localmente via volumes do Docker.
  
  * **Receptor UDP (Node.js):** Criação de um servidor assíncrono em Node.js (`index.js`) que escuta na porta **41234/udp**. O serviço decodifica os payloads binários formatados em **MsgPack** (emulando o payload do ESP32) e mapeia os dados para o esquema de séries temporais (Measurement `log_corrida`), dividindo-os em:
  
    * **Tags:** `estado_robo` (a FSM), `id_corrida`, `id_labirinto` e `objetivo`.
    
    * **Fields:** `bateria`, `pos_x`, `pos_y`, `orientacao`, `erro_pid`, `dist_frontal`, `dist_esq`, `dist_dir`, `pwm_esq`, `pwm_dir`, `velocidade_media`.
  
  * **Simulador de Telemetria (`mock_sender.js`):** Script gerador de dados falsos que simula o fluxo do robô real enviando pacotes em tempo real. Ele simula sequencialmente três perfis de corrida distintos para testes de estresse e visualização:
  
    1. `run_test_01_sucesso`: corrida de mapeamento até o centro.
    2. `run_test_02_falha_bateria`: corrida interrompida por erro crítico de bateria baixa.
    3. `run_test_03_fast_run`: corrida rápida otimizada em alta velocidade.
  
  * **Containerização:** Dockerfile e arquivo `docker-compose.yml` criados dentro da pasta `src/backend` para orquestração automática e isolamento do ambiente de execução.

---

## Como testar

1. Abra um terminal e navegue até a pasta do backend:

   ```bash
   cd src/backend
   ```

2. Suba a infraestrutura Docker:

   ```bash
   docker compose up -d
   ```

3. Acompanhe a inicialização e os logs de recebimento de pacotes:

   ```bash
   docker compose logs -f backend
   ```

4. Em um novo terminal (também em `src/backend`), inicie o simulador UDP:

   ```bash
   npm run mock
   ```

5. Confirme na tela de logs que as mensagens UDP estão sendo decodificadas do MsgPack e gravadas no InfluxDB.

---

# Guia Prático: Como funciona o Painel do InfluxDB

Você pode acompanhar e auditar graficamente a telemetria gravada pelo simulador.

## Acesso

Abra no navegador:

```txt
http://localhost:8086
```

**Usuário:** `admin`  
**Senha:** `adminpassword123`

## Interface Visual

No menu lateral esquerdo, clique no ícone de gráfico (**Data Explorer**).

## Filtragem e Consulta (Painel Inferior)

### FROM (Bucket)

Selecione:

```txt
micromouse_telemetria
```

### _measurement

Selecione:

```txt
log_corrida
```

### Filtro Principal (`id_corrida`)

Escolha qual corrida você quer visualizar:

* `run_test_01_sucesso`
* `run_test_02_falha_bateria`
* `run_test_03_fast_run`

> Filtrar por corrida é crucial para evitar que dados de tentativas diferentes se sobreponham no gráfico.

### Fields (Métricas)

Marque as variáveis que deseja acompanhar:

* Para ver o trajeto espacial: selecione `pos_x` e `pos_y`.
* Para ver o desgaste de energia: selecione `bateria` (veja como ela cai rapidamente na corrida com falha).
* Para analisar a estabilidade do robô: selecione `erro_pid` e veja o ajuste dos motores (`pwm_esq`, `pwm_dir`).
* Para verificar os sensores de colisão: selecione `dist_frontal`, `dist_esq` e `dist_dir`.

### Intervalo de Tempo

No canto superior direito, garanta que está selecionado:

* `Past 1h`
* ou `Past 15m`

### Renderização

Clique no botão azul **Submit** (canto inferior direito) para gerar o gráfico temporal de telemetria.

---

## Issues relacionadas

Resolve #114