### PR TITLE
feat(telemetria): adiciona paineis do grafana e refatora mock de dados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ src/firmware/managed_components/
 src/firmware/sdkconfig
 src/firmware/sdkconfig.old
 src/firmware/dependencies.lock
+.clangd

--- a/src/backend/docker-compose.yml
+++ b/src/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   influxdb:
     image: influxdb:2.7
@@ -9,7 +7,7 @@ services:
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=admin
-      - DOCKER_INFLUXDB_INIT_PASSWORD=123
+      - DOCKER_INFLUXDB_INIT_PASSWORD=senha123456
       - DOCKER_INFLUXDB_INIT_ORG=micromouse
       - DOCKER_INFLUXDB_INIT_BUCKET=micromouse_telemetria
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=micromouse-token-12345
@@ -40,6 +38,21 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  grafana:
+    image: grafana/grafana:latest
+    container_name: micromouse_grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=micromouse_123
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      influxdb:
+        condition: service_healthy
+
 volumes:
   influxdb-data:
   influxdb-config:
+  grafana-data:

--- a/src/backend/mock_sender.js
+++ b/src/backend/mock_sender.js
@@ -6,106 +6,411 @@ dotenv.config();
 
 const UDP_PORT = process.env.UDP_PORT ? parseInt(process.env.UDP_PORT, 10) : 41234;
 const UDP_HOST = process.env.UDP_HOST || '127.0.0.1';
+const SEND_INTERVAL_MS = 150; // 150ms entre amostras — fluído no Grafana
 
 const client = dgram.createSocket('udp4');
 
-// Definições de corridas diferentes para simular comportamentos variados
-const runs = [
-  {
-    id_corrida: "run_test_01_sucesso",
-    id_labirinto: "16x16_standard",
-    stream: [
-      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.0, dist_frontal: 150 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.38, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.05, dist_frontal: 140 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.35, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.02, dist_frontal: 130 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.33, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.08, dist_frontal: 120 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.31, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.04, dist_frontal: 110 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.28, posicao_x: 2, posicao_y: 3, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 100 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.25, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.03, dist_frontal: 90 },
-      { estado_fsm: "GOAL_REACHED", bateria_v: 7.22, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.00, dist_frontal: 80 }
-    ]
-  },
-  {
-    id_corrida: "run_test_02_falha_bateria",
-    id_labirinto: "16x16_standard",
-    stream: [
-      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.0, dist_frontal: 150 },
-      { estado_fsm: "MAPPING",     bateria_v: 7.10, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.04, dist_frontal: 140 },
-      { estado_fsm: "MAPPING",     bateria_v: 6.80, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.05, dist_frontal: 130 },
-      { estado_fsm: "MAPPING",     bateria_v: 6.20, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.12, dist_frontal: 120 },
-      { estado_fsm: "ERROR",       bateria_v: 5.75, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.00, dist_frontal: 120 },
-      { estado_fsm: "ERROR",       bateria_v: 5.50, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.00, dist_frontal: 120 }
-    ]
-  },
-  {
-    id_corrida: "run_test_03_fast_run",
-    id_labirinto: "16x16_standard",
-    stream: [
-      { estado_fsm: "FAST_RUN", bateria_v: 7.30, posicao_x: 0, posicao_y: 0, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 150 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.27, posicao_x: 0, posicao_y: 1, orientacao: "NORTE", erro_pid: 0.02, dist_frontal: 140 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.24, posicao_x: 0, posicao_y: 2, orientacao: "NORTE", erro_pid: -0.01, dist_frontal: 130 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.21, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.03, dist_frontal: 120 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.18, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.02, dist_frontal: 110 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.14, posicao_x: 2, posicao_y: 3, orientacao: "NORTE", erro_pid: 0.01, dist_frontal: 100 },
-      { estado_fsm: "FAST_RUN", bateria_v: 7.10, posicao_x: 2, posicao_y: 4, orientacao: "NORTE", erro_pid: 0.02, dist_frontal: 90 }
-    ]
+// ─── Utilitários ────────────────────────────────────────────────
+function lerp(a, b, t) { return a + (b - a) * t; }
+function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+function noise(amp) { return (Math.random() * 2 - 1) * amp; }
+
+// ─── Gerador de waypoints para a corrida 1 ──────────────────────
+// Rota: (0,0)->(4,0)->(4,3)->(7,3)->(7,7)  — 4 segmentos em L
+function generateRun1Waypoints() {
+  const wp = [];
+  // Segmento 1: X de 0→4, Y=0, indo para LESTE
+  for (let x = 0; x <= 4; x++) wp.push({ x, y: 0, dir: 'LESTE' });
+  // Segmento 2: Y de 0→3, X=4, indo para NORTE
+  for (let y = 1; y <= 3; y++) wp.push({ x: 4, y, dir: 'NORTE' });
+  // Segmento 3: X de 4→7, Y=3, indo para LESTE
+  for (let x = 5; x <= 7; x++) wp.push({ x, y: 3, dir: 'LESTE' });
+  // Segmento 4: Y de 3→7, X=7, indo para NORTE
+  for (let y = 4; y <= 7; y++) wp.push({ x: 7, y, dir: 'NORTE' });
+  return wp;
+}
+
+// ─── Gerador de waypoints para a corrida 3 (fast run) ───────────
+// Rota direta: (0,0)->(7,0)->(7,7) — 2 segmentos longos
+function generateRun3Waypoints() {
+  const wp = [];
+  // Segmento 1: X de 0→7, Y=0, LESTE
+  for (let x = 0; x <= 7; x++) wp.push({ x, y: 0, dir: 'LESTE' });
+  // Segmento 2: Y de 0→7, X=7, NORTE
+  for (let y = 1; y <= 7; y++) wp.push({ x: 7, y, dir: 'NORTE' });
+  return wp;
+}
+
+// ─── Sensores ToF coerentes com a orientação ─────────────────────
+// O robô se move dentro de um grid 16x16. As paredes do corredor
+// ficam a ~180mm. Quando se aproxima de uma parede à frente,
+// dist_frontal cai. Ao girar, a parede frontal vira lateral.
+function computeSensors(posX, posY, dir, distToNextWall) {
+  const WALL_FAR = 180;   // corredor aberto (mm)
+  const WALL_CLOSE = 20;  // parede muito próxima (mm)
+
+  let frontal, esq, dir_dist;
+
+  if (distToNextWall <= 0) {
+    // Encostado na parede — célula final de um segmento
+    frontal = WALL_CLOSE;
+  } else if (distToNextWall >= 4) {
+    // Corredor longo à frente
+    frontal = WALL_FAR;
+  } else {
+    // Aproximando: interpola de 180→20 conforme distância ao wall
+    frontal = lerp(WALL_FAR, WALL_CLOSE, 1 - (distToNextWall / 4));
   }
-];
 
-let activeRunIndex = 0;
-let currentStepIndex = 0;
+  // Paredes laterais: sempre presentes no corredor (exceto becos sem saída)
+  const lateralBase = 85;
+  esq = lateralBase + Math.round(noise(5));
+  dir_dist = lateralBase + Math.round(noise(5));
 
-function sendTelemetry() {
-  const currentRun = runs[activeRunIndex];
-  const stepData = currentRun.stream[currentStepIndex];
+  // Se acabamos de virar e a parede frontal antiga agora é lateral
+  // (sinalizado por distToNextWall === 0, i.e. estamos na célula de curva)
+  if (distToNextWall <= 0) {
+    // A parede que estava à frente agora está ao lado
+    // Dependendo da direção de curva, ela fica à esquerda ou direita
+    // Simplificação: ao virar à esquerda, a parede vai para a esquerda
+    esq = WALL_CLOSE + Math.round(noise(3));
+    frontal = WALL_FAR; // Novo corredor aberto à frente após a curva
+  }
 
-  // Adiciona campos calculados/metadados dinâmicos
-  const isFastRun = stepData.estado_fsm === "FAST_RUN";
-  const fullTelemetry = {
-    ...stepData,
-    timestamp: Math.floor(Date.now() / 1000),
-    id_corrida: currentRun.id_corrida,
-    id_labirinto: currentRun.id_labirinto,
-    objetivo: stepData.estado_fsm === "GOAL_REACHED" ? "S" : "N",
-    dist_esq: 85 + Math.floor(Math.sin(currentStepIndex) * 5),
-    dist_dir: 85 - Math.floor(Math.sin(currentStepIndex) * 5),
-    // Simula motores mais rápidos e estáveis no FAST_RUN
-    pwm_esq: isFastRun ? 210 : 120 + Math.floor(Math.random() * 8),
-    pwm_dir: isFastRun ? 212 : 120 + Math.floor(Math.random() * 8),
-    velocidade_media: isFastRun ? 0.85 + (Math.random() * 0.05) : 0.35 + (Math.random() * 0.03)
-  };
+  // Ruído de sensor ToF (±3mm)
+  frontal = clamp(Math.round(frontal + noise(3)), 10, 255);
+  esq = clamp(Math.round(esq + noise(3)), 10, 255);
+  dir_dist = clamp(Math.round(dir_dist + noise(3)), 10, 255);
 
-  // Codifica em MsgPack
-  const msgBuffer = Buffer.from(encode(fullTelemetry));
+  return { dist_frontal: frontal, dist_esq: esq, dist_dir: dir_dist };
+}
 
-  console.log(`[Mock Sender] [${currentRun.id_corrida}] Enviando passo ${currentStepIndex + 1}/${currentRun.stream.length}...`);
+// ─── Definição das 3 corridas ────────────────────────────────────
 
-  client.send(msgBuffer, 0, msgBuffer.length, UDP_PORT, UDP_HOST, (err) => {
-    if (err) {
-      console.error('[Mock Sender] Erro ao enviar pacote UDP:', err.message);
+// Cada corrida é um gerador assíncrono que yields os frames de telemetria.
+// Isso permite pausas entre corridas e controle fino do tempo.
+
+function* runTest01Sucesso() {
+  const waypoints = generateRun1Waypoints();
+  const totalSteps = waypoints.length;
+  // Índices das células de curva (onde muda de direção)
+  const turnIndices = [];
+  for (let i = 1; i < waypoints.length; i++) {
+    if (waypoints[i].dir !== waypoints[i - 1].dir) {
+      turnIndices.push(i);
     }
-  });
+  }
 
-  currentStepIndex++;
+  let step = 0;
+  for (const wp of waypoints) {
+    const progress = step / (totalSteps - 1); // 0..1
 
-  // Se a corrida ativa terminar, passa para a próxima após uma breve pausa no console
-  if (currentStepIndex >= currentRun.stream.length) {
-    console.log(`\n=== FIM DA CORRIDA: ${currentRun.id_corrida} ===`);
-    activeRunIndex = (activeRunIndex + 1) % runs.length;
-    currentStepIndex = 0;
-    console.log(`=== PREPARANDO PRÓXIMA CORRIDA: ${runs[activeRunIndex].id_corrida} ===\n`);
+    // Bateria: 8.4V → 7.8V, decaimento linear suave
+    const bateria = lerp(8.4, 7.8, progress);
+
+    // Detecta se estamos em uma curva (este passo ou anterior)
+    const isTurnCell = turnIndices.includes(step);
+    const isApproachingTurn = turnIndices.includes(step + 1);
+
+    // Velocidade: acelera nas retas, desacelera nas curvas
+    let velocidadeMedia;
+    if (isTurnCell) {
+      velocidadeMedia = 0.10 + noise(0.02);
+    } else if (isApproachingTurn) {
+      velocidadeMedia = lerp(0.5, 0.1, 0.6) + noise(0.02);
+    } else {
+      velocidadeMedia = 0.50 + noise(0.02);
+    }
+
+    // PID: nas retas oscila levemente, nas curvas dá pico alto e converge
+    let erroPid;
+    if (isTurnCell) {
+      // Pico alto no momento da curva
+      erroPid = (Math.random() > 0.5 ? 1 : -1) * (0.8 + Math.random() * 0.4);
+    } else {
+      // Verifica se a curva foi há 1 passo (convergindo)
+      const prevTurn = turnIndices.find(ti => ti === step - 1);
+      if (prevTurn !== undefined) {
+        erroPid = noise(0.15); // convergindo rápido
+      } else {
+        erroPid = noise(0.03); // ruído leve nas retas
+      }
+    }
+
+    // Distância até a próxima parede (em células) para o sensor frontal
+    let distToNextWall = 4; // padrão: corredor aberto
+    for (const ti of turnIndices) {
+      if (ti > step) {
+        distToNextWall = ti - step;
+        break;
+      }
+      if (ti === step) {
+        distToNextWall = 0; // na curva
+        break;
+      }
+    }
+    // Se não há mais curvas à frente, corredor aberto
+    if (step > (turnIndices[turnIndices.length - 1] || 0)) {
+      distToNextWall = 4;
+    }
+
+    const sensors = computeSensors(wp.x, wp.y, wp.dir, distToNextWall);
+
+    // Estado do robô
+    let estado;
+    if (step === 0) estado = 'CALIBRATING';
+    else if (step === totalSteps - 1) estado = 'GOAL_REACHED';
+    else estado = 'MAPPING';
+
+    yield {
+      estado_fsm: estado,
+      bateria_v: Math.round(bateria * 100) / 100,
+      posicao_x: wp.x,
+      posicao_y: wp.y,
+      orientacao: wp.dir,
+      erro_pid: Math.round(erroPid * 1000) / 1000,
+      velocidade_media: Math.round(velocidadeMedia * 1000) / 1000,
+      ...sensors,
+    };
+
+    step++;
   }
 }
 
-console.log(`[Mock Sender] Iniciando simulador de telemetria UDP (${UDP_HOST}:${UDP_PORT})...`);
-console.log(`Simulando sequencialmente ${runs.length} tipos de corridas.`);
-console.log('Pressione CTRL+C para parar.\n');
+function* runTest02FalhaBateria() {
+  const waypoints = [
+    { x: 0, y: 0, dir: 'LESTE' },
+    { x: 1, y: 0, dir: 'LESTE' },
+    { x: 2, y: 0, dir: 'NORTE' },  // curva
+    { x: 2, y: 1, dir: 'NORTE' },
+    { x: 2, y: 2, dir: 'NORTE' },  // aqui a bateria falha
+  ];
+  const totalSteps = waypoints.length;
+  const failureStep = 3; // índice do passo onde a bateria cai abruptamente
+  const stepsAfterFailure = 5; // alguns frames de "apagão" antes de parar
 
-// Envia telemetria a cada 1 segundo
-const interval = setInterval(sendTelemetry, 1000);
+  let step = 0;
+  let postFailureCount = 0;
+
+  // Fase normal (até o failureStep)
+  for (let i = 0; i < waypoints.length; i++) {
+    const wp = waypoints[i];
+    const progress = i / (totalSteps - 1);
+
+    if (i < failureStep) {
+      // Bateria: 7.4V com decaimento suave
+      const bateria = lerp(7.4, 7.2, progress);
+      const isTurn = i === 2; // curva em (2,0)
+      const velocidadeMedia = isTurn ? 0.12 + noise(0.02) : 0.40 + noise(0.03);
+      const erroPid = isTurn ? (Math.random() > 0.5 ? 1 : -1) * 0.7 : noise(0.04);
+
+      const sensors = computeSensors(wp.x, wp.y, wp.dir, isTurn ? 0 : 3);
+
+      yield {
+        estado_fsm: i === 0 ? 'CALIBRATING' : 'MAPPING',
+        bateria_v: Math.round(bateria * 100) / 100,
+        posicao_x: wp.x,
+        posicao_y: wp.y,
+        orientacao: wp.dir,
+        erro_pid: Math.round(erroPid * 1000) / 1000,
+        velocidade_media: Math.round(velocidadeMedia * 1000) / 1000,
+        ...sensors,
+      };
+      step++;
+
+    } else if (i === failureStep) {
+      // ── QUEDA ABRUPTA DE BATERIA ──
+      // Bateria cai de ~7.1V para <5.5V
+      yield {
+        estado_fsm: 'ERROR',
+        bateria_v: 5.40,
+        posicao_x: wp.x,
+        posicao_y: wp.y,
+        orientacao: wp.dir,
+        erro_pid: 0.85,  // trava em valor alto
+        velocidade_media: 0.0,
+        dist_frontal: 130,
+        dist_esq: 85,
+        dist_dir: 82,
+      };
+      step++;
+
+    } else {
+      // Não deveria chegar aqui nos waypoints normais
+      break;
+    }
+  }
+
+  // Fase de "apagão": robô está morto, valores estáticos
+  const lastWp = waypoints[failureStep];
+  for (let i = 0; i < stepsAfterFailure; i++) {
+    yield {
+      estado_fsm: 'ERROR',
+      bateria_v: Math.round(lerp(5.4, 5.0, i / stepsAfterFailure) * 100) / 100,
+      posicao_x: lastWp.x,
+      posicao_y: lastWp.y,
+      orientacao: lastWp.dir,
+      erro_pid: 0.85,  // travado
+      velocidade_media: 0.0,
+      dist_frontal: 130,
+      dist_esq: 85,
+      dist_dir: 82,
+    };
+  }
+}
+
+function* runTest03FastRun() {
+  const waypoints = generateRun3Waypoints();
+  const totalSteps = waypoints.length;
+  const turnIndices = [];
+  for (let i = 1; i < waypoints.length; i++) {
+    if (waypoints[i].dir !== waypoints[i - 1].dir) {
+      turnIndices.push(i);
+    }
+  }
+
+  let step = 0;
+  for (const wp of waypoints) {
+    const progress = step / (totalSteps - 1);
+
+    // Bateria: 8.2V → 7.4V (consumo ligeiramente maior)
+    const bateria = lerp(8.2, 7.4, progress);
+
+    const isTurnCell = turnIndices.includes(step);
+    const isApproachingTurn = turnIndices.includes(step + 1);
+
+    // Velocidade alta e estável (mapa conhecido)
+    let velocidadeMedia;
+    if (isTurnCell) {
+      velocidadeMedia = 0.30 + noise(0.01); // nem para tanto na curva
+    } else if (isApproachingTurn) {
+      velocidadeMedia = lerp(0.80, 0.30, 0.5) + noise(0.01);
+    } else {
+      velocidadeMedia = 0.80 + noise(0.01);
+    }
+
+    // PID extremamente estável — controle calibrado
+    let erroPid;
+    if (isTurnCell) {
+      erroPid = (Math.random() > 0.5 ? 1 : -1) * (0.15 + Math.random() * 0.1);
+    } else {
+      const prevTurn = turnIndices.find(ti => ti === step - 1);
+      if (prevTurn !== undefined) {
+        erroPid = noise(0.03);
+      } else {
+        erroPid = noise(0.008); // muito estável
+      }
+    }
+
+    let distToNextWall = 4;
+    for (const ti of turnIndices) {
+      if (ti > step) {
+        distToNextWall = ti - step;
+        break;
+      }
+      if (ti === step) {
+        distToNextWall = 0;
+        break;
+      }
+    }
+    if (step > (turnIndices[turnIndices.length - 1] || 0)) {
+      distToNextWall = 4;
+    }
+
+    const sensors = computeSensors(wp.x, wp.y, wp.dir, distToNextWall);
+
+    let estado;
+    if (step === 0) estado = 'FAST_RUN';
+    else if (step === totalSteps - 1) estado = 'GOAL_REACHED';
+    else estado = 'FAST_RUN';
+
+    yield {
+      estado_fsm: estado,
+      bateria_v: Math.round(bateria * 100) / 100,
+      posicao_x: wp.x,
+      posicao_y: wp.y,
+      orientacao: wp.dir,
+      erro_pid: Math.round(erroPid * 1000) / 1000,
+      velocidade_media: Math.round(velocidadeMedia * 1000) / 1000,
+      ...sensors,
+    };
+
+    step++;
+  }
+}
+
+// ─── Orquestrador das corridas ───────────────────────────────────
+const runs = [
+  { id_corrida: 'run_test_01_sucesso',      id_labirinto: '16x16_standard', generator: runTest01Sucesso },
+  { id_corrida: 'run_test_02_falha_bateria', id_labirinto: '16x16_standard', generator: runTest02FalhaBateria },
+  { id_corrida: 'run_test_03_fast_run',      id_labirinto: '16x16_standard', generator: runTest03FastRun },
+];
+
+let activeRunIndex = 0;
+let currentGen = null;
+let intervalHandle = null;
+const PAUSE_BETWEEN_RUNS_MS = 2000;
+
+function startRun(index) {
+  const run = runs[index];
+  currentGen = run.generator();
+  console.log(`\n═══ INICIANDO CORRIDA: ${run.id_corrida} ═══`);
+
+  intervalHandle = setInterval(() => {
+    const result = currentGen.next();
+
+    if (result.done) {
+      // Corrida terminou — limpa timer e inicia a próxima após pausa
+      clearInterval(intervalHandle);
+      intervalHandle = null;
+      console.log(`═══ FIM DA CORRIDA: ${run.id_corrida} ═══`);
+
+      activeRunIndex = (activeRunIndex + 1) % runs.length;
+      if (activeRunIndex === 0) {
+        console.log('\n▹ Todas as corridas foram completadas. Reiniciando ciclo...\n');
+      }
+
+      setTimeout(() => startRun(activeRunIndex), PAUSE_BETWEEN_RUNS_MS);
+      return;
+    }
+
+    const frame = result.value;
+    const fullTelemetry = {
+      ...frame,
+      timestamp: Math.floor(Date.now() / 1000),
+      id_corrida: run.id_corrida,
+      id_labirinto: run.id_labirinto,
+      objetivo: frame.estado_fsm === 'GOAL_REACHED' ? 'S' : 'N',
+      pwm_esq: frame.velocidade_media > 0.6 ? 210 + Math.round(noise(2)) : 120 + Math.round(noise(4)),
+      pwm_dir: frame.velocidade_media > 0.6 ? 212 + Math.round(noise(2)) : 120 + Math.round(noise(4)),
+    };
+
+    const msgBuffer = Buffer.from(encode(fullTelemetry));
+
+    client.send(msgBuffer, 0, msgBuffer.length, UDP_PORT, UDP_HOST, (err) => {
+      if (err) console.error('[Mock Sender] Erro ao enviar UDP:', err.message);
+    });
+
+    console.log(
+      `[Mock Sender] [${run.id_corrida}] ` +
+      `pos=(${frame.posicao_x},${frame.posicao_y}) ${frame.orientacao} ` +
+      `bat=${frame.bateria_v}V vel=${frame.velocidade_media}m/s ` +
+      `pid=${frame.erro_pid} frontal=${frame.dist_frontal}mm ` +
+      `estado=${frame.estado_fsm}`
+    );
+  }, SEND_INTERVAL_MS);
+}
+
+// ─── Início ──────────────────────────────────────────────────────
+console.log(`[Mock Sender] Iniciando simulador de telemetria UDP (${UDP_HOST}:${UDP_PORT})`);
+console.log(`[Mock Sender] Intervalo entre amostras: ${SEND_INTERVAL_MS}ms`);
+console.log(`[Mock Sender] Simulando ${runs.length} corridas sequenciais em loop.`);
+console.log(`[Mock Sender] Pressione CTRL+C para parar.\n`);
+
+startRun(0);
 
 process.on('SIGINT', () => {
-  clearInterval(interval);
+  if (intervalHandle) clearInterval(intervalHandle);
   client.close(() => {
     console.log('[Mock Sender] Encerrado.');
     process.exit(0);


### PR DESCRIPTION
## Descrição
Este Pull Request implementa a interface visual de telemetria no Grafana, conectando-a ao bucket do InfluxDB. As alterações incluem a configuração dos gráficos em tempo real (odometria, PID, bateria e ToF) e a refatoração do script de mock para gerar simulações de física mais realistas para validação do painel.

**Relaciona-se com:** Closes #188

## Evidências Visuais
## Critérios de Aceite (DoD) Atendidos:
- [x] `[Software]` Conexão (Data Source) configurada com linguagem Flux.
- [x] `[Software]` Rastreador de posição espacial (XY Chart) cravado entre 0 e 16.
- [x] `[Software]` Medidores de tensão da bateria agrupados por `id_corrida`.
- [x] `[Software]` Séries temporais de `erro_pid` e sensores ToF plotadas.
- [x] `[Software]` `docker-compose.yml` atualizado para subir Grafana e InfluxDB simultaneamente.
- [x] `[Software]` Script `mock_sender.js` refatorado para suportar geradores simulando física real.

## Como testar
1. Fazer o checkout para esta branch (`feat/hu-4.8.1-grafana-dashboards`).
2. Subir os contêineres: `docker compose up -d` (dentro da pasta `backend`).
3. Rodar o emulador do Wokwi via VS Code (ou o novo mock com `npm run mock`).
4. Acessar `http://localhost:3000` e verificar se os dados estão sendo plotados nos painéis de Bateria, PID, Odometria e ToF.
<img width="1909" height="923" alt="image" src="https://github.com/user-attachments/assets/799fd825-12f0-4c7b-ad3c-f523760b84d3" />
