### PR TITLE
Test/202 testes e2e frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,7 @@ src/firmware/sdkconfig
 src/firmware/sdkconfig.old
 src/firmware/dependencies.lock
 .clangd
+
+# Playwright
+playwright-report/
+test-results/

--- a/src/frontend/__tests__/e2e/dashboard.spec.ts
+++ b/src/frontend/__tests__/e2e/dashboard.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+async function waitForTelemetryUpdate(page: Page, initialTimestamp: string) {
+  await expect(async () => {
+    const timestamp = await page.locator('.font-mono.text-sm.text-slate-500.font-medium').first().textContent();
+    expect(timestamp).not.toBe(initialTimestamp);
+  }).toPass({ timeout: 5000 });
+}
+
+test.describe('Dashboard (Simulação)', () => {
+  test.setTimeout(45000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    const simBtn = page.getByRole('button', { name: /MODO SIMULAÇÃO/i });
+    await expect(simBtn).toBeVisible();
+    await page.locator('.aspect-square').first().waitFor();
+  });
+
+  test('deve mostrar métricas iniciais corretamente', async ({ page }) => {
+    await expect(page.getByText('Bateria', { exact: true })).toBeVisible();
+    await expect(page.getByText('Velocidade', { exact: true })).toBeVisible();
+    await expect(page.getByText('Posição Atual', { exact: true })).toBeVisible();
+    await expect(page.getByText('Estado do Robô', { exact: true })).toBeVisible();
+
+    const bateria = await page.locator('.tabular-nums').first().textContent();
+    expect(bateria).toMatch(/\d+\.\d+V/);
+  });
+
+  test('deve alternar entre modos de override: Auto, Exploração, Alta Performance', async ({ page }) => {
+    const autoBtn = page.getByRole('button', { name: 'Auto' });
+    const exploracaoBtn = page.getByRole('button', { name: 'Exploração' });
+    const performanceBtn = page.getByRole('button', { name: 'Alta Performance' });
+
+    await expect(autoBtn).toBeVisible();
+    await expect(exploracaoBtn).toBeVisible();
+    await expect(performanceBtn).toBeVisible();
+
+    await exploracaoBtn.click();
+    await expect(page.getByText('FAST_RUN', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('Volta Atual', { exact: true })).not.toBeVisible();
+
+    await performanceBtn.click();
+    await expect(page.getByText('FAST_RUN').first()).toBeVisible();
+    await expect(page.getByText('Volta Atual', { exact: true })).toBeVisible();
+    await expect(page.getByText('Melhor Volta', { exact: true })).toBeVisible();
+
+    await autoBtn.click();
+  });
+
+  test('deve atualizar telemetria automaticamente (simulação)', async ({ page }) => {
+    const posInicial = await page.locator('.tabular-nums').nth(4).textContent();
+    const timestampInicial = await page.locator('.font-mono.text-sm.text-slate-500.font-medium').first().textContent();
+
+    await waitForTelemetryUpdate(page, timestampInicial!);
+
+    const posAtual = await page.locator('.tabular-nums').nth(4).textContent();
+    expect(posAtual).not.toBe(posInicial);
+
+    const robotCell = page.locator('div.bg-blue-500\\/20.rounded-full').first();
+    await expect(robotCell).toBeVisible();
+  });
+
+  test('deve exibir alerta crítico de bateria quando tensão < 6.8V', async ({ page }) => {
+    await expect(page.getByText('Alerta Crítico:').first()).toBeVisible({ timeout: 25000 });
+    const alertText = await page.getByText(/Bateria Crítica/).first().textContent();
+    expect(alertText).toContain('Bateria Crítica');
+  });
+
+  test('deve exibir erro de hardware quando estado = ERROR', async ({ page }) => {
+    await expect(page.getByText('Alarme Crítico de Hardware:').first()).toBeVisible({ timeout: 30000 });
+    const causaErro = await page.getByText(/Parada de Emergência/).first().textContent();
+    expect(causaErro).toBeTruthy();
+    const estadoCard = page.locator('.bg-red-100, .border-red-400').filter({ hasText: 'ERROR' }).first();
+    await expect(estadoCard).toBeVisible({ timeout: 35000 });
+  });
+
+  test('deve abrir/fechar gaveta de logs e mostrar conteúdo adequado', async ({ page }) => {
+    const toggleBtn = page.getByRole('button', { name: /Logs de Interrupção|Desempenho da Corrida|Ocultar Logs|Ocultar Desempenho/ }).first();
+    const drawer = page.locator('.bg-slate-900\\/95.backdrop-blur-md.rounded-2xl').first();
+
+    await toggleBtn.click();
+    await expect(drawer).toBeVisible();
+    await expect(page.getByRole('button', { name: /Ocultar Logs|Ocultar Desempenho/ }).first()).toBeVisible();
+
+    await toggleBtn.click();
+    await expect(page.getByRole('button', { name: /Logs de Interrupção|Desempenho da Corrida/ }).first()).toBeVisible();
+  });
+
+  test('deve exibir trajeto rápido quando modo FAST_RUN ativo', async ({ page }) => {
+    await page.getByRole('button', { name: 'Alta Performance' }).click();
+    const pontosVerdes = page.locator('.rounded-full.bg-emerald-400, .rounded-full.bg-emerald-500');
+    await expect(pontosVerdes.first()).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/src/frontend/__tests__/e2e/historico.spec.ts
+++ b/src/frontend/__tests__/e2e/historico.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { Buffer } from 'buffer';
+
+const MOCK_RUN_ID = 'corrida_1715456789.json';
+
+const MOCK_HISTORICO = {
+  id_corrida: 'run_001',
+  historico: [
+    { x: 0, y: 7, orientacao: 'NORTE', paredes: [] },
+    { x: 0, y: 6, orientacao: 'NORTE', paredes: [{ x: 0, y: 6, dir: 'NORTE' }] },
+    { x: 0, y: 5, orientacao: 'LESTE', paredes: [{ x: 0, y: 5, dir: 'LESTE' }] },
+    { x: 1, y: 5, orientacao: 'LESTE', paredes: [] },
+    { x: 2, y: 5, orientacao: 'NORTE', paredes: [] },
+    { x: 2, y: 4, orientacao: 'NORTE', paredes: [] },
+  ],
+};
+
+test.describe('Página de Histórico', () => {
+  test.setTimeout(45000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/maze_runs', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([MOCK_RUN_ID]),
+      });
+    });
+
+    await page.route(`**/api/maze_runs/${MOCK_RUN_ID}`, async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(MOCK_HISTORICO) });
+    });
+
+    await page.goto('/historico');
+    await page.waitForSelector(`text=${MOCK_RUN_ID}`);
+  });
+
+  test('deve carregar lista de corridas da API', async ({ page }) => {
+    await expect(page.getByText(MOCK_RUN_ID).first()).toBeVisible();
+    await expect(page.getByText('1 corrida encontrada').first()).toBeVisible();
+  });
+
+  test('deve carregar detalhes da corrida ao clicar', async ({ page }) => {
+    await page.getByText(MOCK_RUN_ID).first().click();
+    await expect(page.locator('.grid').first()).toBeVisible();
+    await expect(page.getByText(/6 passos/).first()).toBeVisible();
+  });
+
+  test('deve permitir navegação passo a passo', async ({ page }) => {
+    await page.getByText(MOCK_RUN_ID).first().click();
+    await page.waitForSelector('.grid');
+
+    await expect(page.locator('.font-mono.font-bold').first()).toContainText('1/6');
+    await expect(page.locator('.font-mono').filter({ hasText: '(0, 7)' }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: '▶', exact: true }).click();
+    await expect(page.locator('.font-mono.font-bold').first()).toContainText('2/6');
+    await expect(page.locator('.font-mono').filter({ hasText: '(0, 6)' }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: '◀', exact: true }).click();
+    await expect(page.locator('.font-mono.font-bold').first()).toContainText('1/6');
+  });
+
+  test('deve executar replay automático', async ({ page }) => {
+    await page.getByText(MOCK_RUN_ID).first().click();
+    await page.waitForSelector('.grid');
+
+    await page.getByRole('button', { name: '▶ Play' }).click();
+    await page.waitForTimeout(1500);
+
+    const stepText = await page.locator('.font-mono.font-bold').first().textContent();
+    expect(stepText).not.toBe('1/6');
+
+    await page.getByRole('button', { name: /Pausar|Replay/i }).first().click();
+  });
+
+  test('deve resetar para o início', async ({ page }) => {
+    await page.getByText(MOCK_RUN_ID).first().click();
+    await page.waitForSelector('.grid');
+
+    await page.getByRole('button', { name: '▶', exact: true }).click();
+    await page.getByRole('button', { name: '▶', exact: true }).click();
+    await expect(page.locator('.font-mono.font-bold').first()).toContainText('3/6');
+
+    await page.getByRole('button', { name: '⏮' }).click();
+    await expect(page.locator('.font-mono.font-bold').first()).toContainText('1/6');
+  });
+
+  test('deve permitir upload de arquivo JSON', async ({ page }) => {
+    const mockFileContent = JSON.stringify({
+      historico: [
+        { x: 0, y: 0, orientacao: 'NORTE', paredes: [] },
+        { x: 0, y: 1, orientacao: 'NORTE', paredes: [{ x: 0, y: 1, dir: 'LESTE' }] },
+      ],
+    });
+
+    const input = page.locator('input[type="file"]');
+    await input.setInputFiles({
+      name: 'upload.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(mockFileContent, 'utf-8'),
+    });
+
+    await expect(page.getByText('upload.json').first()).toBeVisible();
+    await expect(page.locator('.grid').first()).toBeVisible();
+    await expect(page.getByText(/2 passos/).first()).toBeVisible();
+  });
+
+  test('deve ajustar velocidade do replay', async ({ page }) => {
+    await page.getByText(MOCK_RUN_ID).first().click();
+    await page.waitForSelector('.grid');
+
+    await page.getByRole('button', { name: '10×' }).click();
+    await page.getByRole('button', { name: '▶ Play' }).click();
+    await page.waitForTimeout(600);
+
+    const step = await page.locator('.font-mono.font-bold').first().textContent();
+    const current = parseInt(step!.split('/')[0]);
+    expect(current).toBeGreaterThan(1);
+  });
+});

--- a/src/frontend/__tests__/e2e/navegacao.spec.ts
+++ b/src/frontend/__tests__/e2e/navegacao.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navegação e Layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('sidebar deve conter links para Dashboard e Histórico', async ({ page }) => {
+    const dashboardLink = page.getByRole('link', { name: 'Dashboard' }).first();
+    const historicoLink = page.getByRole('link', { name: 'Histórico' }).first();
+    await expect(dashboardLink).toBeVisible();
+    await expect(historicoLink).toBeVisible();
+  });
+
+  test('navegação para Histórico e volta para Dashboard', async ({ page }) => {
+    await page.getByRole('link', { name: 'Histórico' }).first().click();
+    await expect(page).toHaveURL(/\/historico/);
+    await expect(page.getByText('Histórico do Labirinto').first()).toBeVisible();
+
+    await page.getByRole('link', { name: 'Dashboard' }).first().click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText('Dashboard', { exact: true }).first()).toBeVisible();
+  });
+
+  test('exibe status de conexão (simulação mostra como conectado)', async ({ page }) => {
+    const wifiIcon = page.locator('.text-emerald-500, .text-amber-500').first();
+    await expect(wifiIcon).toBeVisible();
+    await expect(page.getByText('Conectado').first()).toBeVisible();
+  });
+});

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.3.0",
+        "buffer": "^6.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.16.0",
@@ -22,7 +23,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^24.12.3",
+        "@playwright/test": "^1.60.0",
+        "@types/node": "^24.13.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -570,6 +572,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -1148,13 +1166,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -1496,6 +1514,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
@@ -1554,6 +1592,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2081,6 +2143,26 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2657,6 +2739,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -2980,9 +3109,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.3.0",
+    "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",
@@ -24,7 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^24.12.3",
+    "@playwright/test": "^1.60.0",
+    "@types/node": "^24.13.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './__tests__/e2e', 
+  
+  timeout: 30 * 1000,
+  expect: { timeout: 5000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'html',
+  
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 5173',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    }
+  ]
+});

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.playwright.json" }
   ]
 }

--- a/src/frontend/tsconfig.playwright.json
+++ b/src/frontend/tsconfig.playwright.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "module": "esnext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true
+  },
+  "include": ["playwright.config.ts", "__tests__/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Descrição

Implementa testes E2E com Playwright para o frontend, cobrindo os fluxos principais do Dashboard, Página de Histórico e Navegação/Layout.

Resolve #202.

---

## Objetivo dos Testes

O principal objetivo destes testes E2E é garantir a confiabilidade e reatividade da interface do usuário sob condições que simulam o fluxo de telemetria em tempo real do robô. 
Especificamente, eles validam:
* **Fidelidade da Telemetria e Reatividade:** Garantir que a interface atualize e renderize o mapa e as métricas do labirinto sem travamentos, mesmo sob processamento assíncrono de alta frequência.
* **Integridade dos Fluxos de Usuário:** Validar que as funcionalidades críticas (como navegação de páginas, upload de mapas JSON, replay de corridas, exportação de CSV/JSON e transição entre os modos de operação) se comportem exatamente como esperado.
* **Resiliência a Falhas:** Assegurar que os badges de estado da máquina de estados (FSM) e o status de conexão reflitam os dados reais de forma correta e síncrona.

---

## O que foi adicionado

- `__tests__/e2e/dashboard.spec.ts` — 7 testes de simulação do Dashboard (métricas, modos de override, telemetria, alertas, gaveta de logs, trajeto FAST_RUN)
- `__tests__/e2e/historico.spec.ts` — 7 testes da Página de Histórico (listagem via API, navegação passo a passo, replay, upload de JSON, velocidade)
- `__tests__/e2e/navegacao.spec.ts` — 3 testes de navegação e layout (sidebar, roteamento entre páginas, status de conexão)
- `playwright.config.ts` — configuração do Playwright com servidor de desenvolvimento integrado
- `.gitignore` atualizado para ignorar `playwright-report/` e `test-results/`

**Total: 17 testes E2E**

---

## Como testar

### Pré-requisitos (após `git pull`)

```bash
cd src/frontend
npm install
npx playwright install chromium
```

### Rodar todos os testes

```bash
npx playwright test --project=chromium --reporter=list
```

### Rodar com interface visual (recomendado para inspecionar cada passo)

```bash
npx playwright test --ui
```

### Rodar um arquivo específico

```bash
npx playwright test dashboard.spec.ts --project=chromium
npx playwright test historico.spec.ts --project=chromium
npx playwright test navegacao.spec.ts --project=chromium
```

> O servidor de desenvolvimento (`npm run dev`) é iniciado automaticamente pelo Playwright antes dos testes e encerrado ao final. Não é necessário rodá-lo manualmente.
