### PR TITLE
feat: Implementa comandos build e clean ao Makefile (#224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: help install run backend frontend mock
+.PHONY: help install build run backend frontend mock clean
 
 help:
 	@echo "Comandos disponíveis:"
 	@echo "  make install  - Instala as dependências do Backend e Frontend"
+	@echo "  make build    - Compila a versão de produção do Frontend"
 	@echo "  make run      - Sobe o Backend, Frontend e o Mock em paralelo"
 	@echo "  make backend  - Sobe apenas o Backend"
 	@echo "  make frontend - Sobe apenas o Frontend"
 	@echo "  make mock     - Sobe apenas o Mock Sender"
+	@echo "  make clean    - Remove as pastas node_modules e diretórios de build"
 
 install:
 	@echo "=> Instalando dependências do Backend..."
@@ -14,6 +16,10 @@ install:
 	@echo "=> Instalando dependências do Frontend..."
 	@cd src/frontend && npm install
 	@echo "=> Dependências instaladas!"
+
+build:
+	@echo "=> Compilando Frontend para produção..."
+	@cd src/frontend && npm run build
 
 backend:
 	@echo "=> Iniciando Backend..."
@@ -32,3 +38,10 @@ run:
 	@echo "=> Iniciando todos os serviços (Backend, Frontend e Mock)..."
 	@echo "=> Pressione Ctrl+C para encerrar todos."
 	@$(MAKE) -j3 backend frontend mock
+
+clean:
+	@echo "=> Limpando arquivos temporários e compilados..."
+	@rm -rf src/backend/node_modules
+	@rm -rf src/frontend/node_modules
+	@rm -rf src/frontend/dist
+	@echo "=> Limpeza concluída!"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ make run
 
 Ao fazer isso, o sistema irá subir o Backend Node.js, a Dashboard em React e o emissor de telemetria UDP do Mock em paralelo. Pressione `Ctrl + C` uma única vez para derrubar tudo.
 
-Caso prefira rodar módulos específicos:
-- `make backend`
-- `make frontend`
-- `make mock`
+Caso prefira rodar ou manipular módulos específicos:
+- `make backend` (Sobe apenas o Node.js)
+- `make frontend` (Sobe apenas a dashboard)
+- `make mock` (Sobe o emissor UDP)
+- `make build` (Gera a versão de produção do frontend)
+- `make clean` (Apaga todas as pastas `node_modules` e pastas de `build` compiladas)

--- a/mkdocs/docs/software/executando_projeto.md
+++ b/mkdocs/docs/software/executando_projeto.md
@@ -50,3 +50,11 @@ Caso você esteja depurando um bug específico e não queira rodar o pacote comp
   ```bash
   make mock
   ```
+* Gera os arquivos estáticos de produção do frontend (útil para testes de deploy):
+  ```bash
+  make build
+  ```
+* Limpa todos os arquivos temporários e dependências instaladas (`node_modules` e pastas de dist/build):
+  ```bash
+  make clean
+  ```


### PR DESCRIPTION
### Descrição
Adição dos comandos de limpeza e compilação solicitados na Definition of Done da Issue #224.

### O que foi feito:
- Implementado o comando `make clean` para varrer dependências temporárias (`node_modules`) e o diretório `dist`.
- Implementado o comando `make build` para testar a compilação de produção do Frontend (`npm run build`).
- Adicionado explicações explícitas de como usar e pra que serve cada comando no `README.md` e na nossa página recém criada do Github Pages (MkDocs).

###  Como Testar:
1. Rode `make build` e valide se a pasta `src/frontend/dist` é gerada com os arquivos estáticos de produção.
2. Rode `make clean` e valide se tanto o `dist` quanto as pastas `node_modules` de backend e frontend são excluídas do sistema.
