### PR TITLE
feat: repassar rota_calculada via Socket.io no backend

### DIFF
--- a/src/backend/__tests__/parser.test.js
+++ b/src/backend/__tests__/parser.test.js
@@ -1,0 +1,101 @@
+import dgram from 'node:dgram';
+import { encode } from '@msgpack/msgpack';
+import { jest } from '@jest/globals';
+import { startServer, shutdown, io, writeApi } from '../index.js';
+
+const TEST_UDP_PORT = 41236;
+const TEST_WS_PORT = 3006;
+
+let client;
+let consoleLogSpy;
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  
+  // Mock writeApi of InfluxDB to avoid connecting/writing to InfluxDB
+  jest.spyOn(writeApi, 'writePoint').mockImplementation(() => {});
+  jest.spyOn(writeApi, 'flush').mockImplementation(() => Promise.resolve());
+  
+  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+  startServer(TEST_UDP_PORT, TEST_WS_PORT);
+  client = dgram.createSocket('udp4');
+});
+
+afterAll(async () => {
+  if (client) {
+    client.close();
+  }
+  consoleLogSpy.mockRestore();
+  await shutdown();
+});
+
+const sendUdpPacket = (buffer) => {
+  return new Promise((resolve, reject) => {
+    client.send(buffer, 0, buffer.length, TEST_UDP_PORT, '127.0.0.1', (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('Parser Unit Tests: MsgPack & JSON with rota_calculada', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('1. Parses JSON packets and extracts rota_calculada', async () => {
+    const emitSpy = jest.spyOn(io, 'emit');
+    
+    const route = [{ x: 0, y: 0 }, { x: 0, y: 1 }, { x: 0, y: 2 }];
+    const payload = {
+      id_corrida: 'test_json_route',
+      estado_fsm: 'FAST_RUN',
+      rota_calculada: route
+    };
+    
+    const jsonStr = JSON.stringify(payload);
+    const buffer = Buffer.from(jsonStr);
+    
+    await sendUdpPacket(buffer);
+    await delay(200);
+
+    // Verify socket.emit was called with telemetry and payload
+    expect(emitSpy).toHaveBeenCalledWith('telemetry', expect.objectContaining({
+      id_corrida: 'test_json_route',
+      rota_calculada: route
+    }));
+
+    // Verify console.log was called for "Rota otimizada recebida"
+    const logCalls = consoleLogSpy.mock.calls.map(args => args.join(' '));
+    expect(logCalls.some(log => log.includes('Rota otimizada recebida: 3 passos'))).toBe(true);
+  });
+
+  test('2. Parses MsgPack packets and extracts rota_calculada', async () => {
+    const emitSpy = jest.spyOn(io, 'emit');
+    
+    const route = [{ x: 1, y: 1 }, { x: 1, y: 2 }];
+    const payload = {
+      id_corrida: 'test_msgpack_route',
+      estado_fsm: 'FAST_RUN',
+      rota_calculada: route
+    };
+    
+    const buffer = Buffer.from(encode(payload));
+    
+    await sendUdpPacket(buffer);
+    await delay(200);
+
+    // Verify socket.emit was called with telemetry and payload
+    expect(emitSpy).toHaveBeenCalledWith('telemetry', expect.objectContaining({
+      id_corrida: 'test_msgpack_route',
+      rota_calculada: route
+    }));
+
+    // Verify console.log was called for "Rota otimizada recebida"
+    const logCalls = consoleLogSpy.mock.calls.map(args => args.join(' '));
+    expect(logCalls.some(log => log.includes('Rota otimizada recebida: 2 passos'))).toBe(true);
+  });
+});

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -55,12 +55,30 @@ server.on('listening', () => {
 
 server.on('message', (msg, rinfo) => {
   try {
-    // Decodifica o payload recebido via MsgPack
-    const data = decode(msg);
-    console.log(`[UDP] Recebido de ${rinfo.address}:${rinfo.port}:`, data);
+    // Tenta decodificar o payload recebido via MsgPack ou JSON.parse()
+    let dadosDecodificados;
+    try {
+      dadosDecodificados = decode(msg);
+    } catch (msgPackErr) {
+      try {
+        dadosDecodificados = JSON.parse(msg.toString());
+      } catch (jsonErr) {
+        throw new Error(`Falha ao decodificar MsgPack e JSON: ${msgPackErr.message} / ${jsonErr.message}`);
+      }
+    }
+
+    console.log(`[UDP] Recebido de ${rinfo.address}:${rinfo.port}:`, dadosDecodificados);
+
+    // Adiciona um console.log condicional avisando que uma rota foi recebida
+    if (dadosDecodificados.rota_calculada) {
+      const passos = Array.isArray(dadosDecodificados.rota_calculada) ? dadosDecodificados.rota_calculada.length : 0;
+      console.log(`Rota otimizada recebida: ${passos} passos`);
+    }
 
     // Envia dados para clientes conectados via WebSocket
-    io.emit('telemetry', data);
+    io.emit('telemetry', dadosDecodificados);
+
+    const data = dadosDecodificados;
 
     // Mapeamento dinâmico e seguro para o esquema InfluxDB
     const estado_robo = data.estado_fsm || data.estado_robo || 'IDLE';

--- a/src/backend/mock_sender.js
+++ b/src/backend/mock_sender.js
@@ -72,7 +72,18 @@ function sendTelemetry() {
     // Simula motores mais rápidos e estáveis no FAST_RUN
     pwm_esq: isFastRun ? 210 : 120 + Math.floor(Math.random() * 8),
     pwm_dir: isFastRun ? 212 : 120 + Math.floor(Math.random() * 8),
-    velocidade_media: isFastRun ? 0.85 + (Math.random() * 0.05) : 0.35 + (Math.random() * 0.03)
+    velocidade_media: isFastRun ? 0.85 + (Math.random() * 0.05) : 0.35 + (Math.random() * 0.03),
+    ...(isFastRun ? {
+      rota_calculada: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 0, y: 2 },
+        { x: 1, y: 2 },
+        { x: 2, y: 2 },
+        { x: 2, y: 3 },
+        { x: 2, y: 4 }
+      ]
+    } : {})
   };
 
   // Codifica em MsgPack


### PR DESCRIPTION
# HU 6.3.2: Repassar rota_calculada via Socket.io no Backend (#249)

## Contexto e Objetivo
Atualmente, o servidor Node.js recebe os pacotes UDP da ESP32 ou do simulador Mock e repassa as informações decodificadas de posição e orientação para o painel React (Frontend) via Websocket.

Esta Pull Request adiciona o suporte no Backend para extrair e retransmitir a propriedade rota_calculada intacta para o Frontend sem causar estouro de memória ou falhas críticas.

---

## Alterações Realizadas

### 1. Servidor Backend (src/backend/index.js)
* **Tratamento de Payload Robusto**: Adicionada compatibilidade para decodificar payloads UDP tanto em formato MsgPack (nativo do robô) quanto em JSON (via JSON.parse como fallback).
* **Logging de Rota**: Adicionado um log console condicional para facilitar o debug no terminal: "Rota otimizada recebida: X passos".
* **WebSocket Emit**: Propagação direta do array rota_calculada no objeto da telemetria enviado via websocket (io.emit('telemetry', dadosDecodificados)).

### 2. Simulador de Telemetria (src/backend/mock_sender.js)
* **Injeção de Rota**: Atualizado o fluxo de simulação de telemetria para injetar um trajeto mockado (rota_calculada) durante o estado de FAST_RUN.

### 3. Testes Automatizados (src/backend/__tests__/parser.test.js)
* **Testes de Decodificação**: Criada uma suíte de testes unitários que valida a decodificação de JSON e MsgPack com rota_calculada, garantindo o correto tratamento dos dados sem requerer conexão ativa com o InfluxDB.

---

## Como Validar

### 1. Testes de Unidade
Execute os testes criados a partir do diretório src/backend:
```bash
npm run test __tests__/parser.test.js
