### PR TITLE
feat: adição de caminhos rota_calculada para os testes de FAST_RUN no…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "@msgpack/msgpack": "^3.1.3",
+        "dotenv": "^17.4.2"
+      },
       "devDependencies": {
         "jsdom": "^29.1.1"
       }
@@ -110,9 +114,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
       "dev": true,
       "funding": [
         {
@@ -218,6 +222,14 @@
         }
       }
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -258,6 +270,17 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -402,21 +425,21 @@
       "dev": true
     },
     "node_modules/tldts": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
       "dev": true,
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^7.4.3"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
       "dev": true
     },
     "node_modules/tough-cookie": {
@@ -444,9 +467,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "devDependencies": {
     "jsdom": "^29.1.1"
+  },
+  "dependencies": {
+    "@msgpack/msgpack": "^3.1.3",
+    "dotenv": "^17.4.2"
   }
 }

--- a/src/backend/mock_sender.js
+++ b/src/backend/mock_sender.js
@@ -48,13 +48,39 @@ const runs = [
     id_corrida: "run_test_03_fast_run",
     id_labirinto: "16x16_standard",
     stream: [
-      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "SUL", erro_pid: 0.0, dist_frontal: 150, paredes: 11 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.30, posicao_x: 0, posicao_y: 1, orientacao: "SUL", erro_pid: 0.01, dist_frontal: 140, paredes: 10 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.25, posicao_x: 0, posicao_y: 2, orientacao: "SUL", erro_pid: -0.01, dist_frontal: 130, paredes: 12 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.20, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.02, dist_frontal: 120, paredes: 5 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.15, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.01, dist_frontal: 110, paredes: 3 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.12, posicao_x: 2, posicao_y: 3, orientacao: "SUL", erro_pid: 0.0, dist_frontal: 100, paredes: 10 },
-      { estado_fsm: "FAST_RUN",    bateria_v: 7.10, posicao_x: 2, posicao_y: 4, orientacao: "SUL", erro_pid: 0.02, dist_frontal: 90, paredes: 14 }
+      { estado_fsm: "CALIBRATING", bateria_v: 7.40, posicao_x: 0, posicao_y: 0, orientacao: "SUL", erro_pid: 0.0, dist_frontal: 150, paredes: 11},
+      
+      // Primeiro sobe, depois vira
+      { estado_fsm: "FAST_RUN",    bateria_v: 7.30, posicao_x: 0, posicao_y: 1, orientacao: "SUL", erro_pid: 0.01, dist_frontal: 140, paredes: 10, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 0, "y": 1 }, { "x": 0, "y": 2 }, { "x": 0, "y": 3 }, { "x": 0, "y": 4 }, { "x": 0, "y": 5 }, { "x": 0, "y": 6 }, { "x": 0, "y": 7 },
+  { "x": 1, "y": 7 }, { "x": 2, "y": 7 }, { "x": 3, "y": 7 }, { "x": 4, "y": 7 }, { "x": 5, "y": 7 }, { "x": 6, "y": 7 }, { "x": 7, "y": 7 }] },
+      
+      // Com pequenas curvas
+      { estado_fsm: "FAST_RUN",    bateria_v: 7.25, posicao_x: 0, posicao_y: 2, orientacao: "SUL", erro_pid: -0.01, dist_frontal: 130, paredes: 12, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 1, "y": 0 }, { "x": 1, "y": 1 }, { "x": 2, "y": 1 }, { "x": 2, "y": 2 }, { "x": 3, "y": 2 }, { "x": 3, "y": 3 }, { "x": 4, "y": 3 },
+  { "x": 4, "y": 4 }, { "x": 5, "y": 4 }, { "x": 5, "y": 5 }, { "x": 6, "y": 5 }, { "x": 6, "y": 6 }, { "x": 7, "y": 6 }, { "x": 7, "y": 7 }] },
+      
+      // Chegando ao centro (8,8)
+      { estado_fsm: "FAST_RUN",    bateria_v: 7.20, posicao_x: 1, posicao_y: 2, orientacao: "LESTE", erro_pid: 0.02, dist_frontal: 120, paredes: 5, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 1, "y": 0 }, { "x": 2, "y": 0 }, { "x": 3, "y": 0 }, { "x": 4, "y": 0 }, { "x": 5, "y": 0 }, { "x": 6, "y": 0 }, { "x": 7, "y": 0 },
+  { "x": 8, "y": 0 }, { "x": 8, "y": 1 }, { "x": 8, "y": 2 }, { "x": 8, "y": 3 }, { "x": 8, "y": 4 }, { "x": 8, "y": 5 }, { "x": 8, "y": 6 }, { "x": 8, "y": 7 },
+  { "x": 8, "y": 8 }] },
+      
+      // Caminho em "L"
+      { estado_fsm: "FAST_RUN",    bateria_v: 7.15, posicao_x: 2, posicao_y: 2, orientacao: "LESTE", erro_pid: -0.01, dist_frontal: 110, paredes: 3, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 1, "y": 0 }, { "x": 2, "y": 0 }, { "x": 3, "y": 0 }, { "x": 4, "y": 0 }, { "x": 5, "y": 0 }, { "x": 6, "y": 0 }, { "x": 7, "y": 0 },
+  { "x": 7, "y": 1 }, { "x": 7, "y": 2 }, { "x": 7, "y": 3 }, { "x": 7, "y": 4 }, { "x": 7, "y": 5 }, { "x": 7, "y": 6 }, { "x": 7, "y": 7 }]  },
+      
+      // Rota mais orgânica
+      { estado_fsm: "FAST_RUN",    bateria_v: 7.12, posicao_x: 2, posicao_y: 3, orientacao: "SUL", erro_pid: 0.0, dist_frontal: 100, paredes: 10, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 0, "y": 1 }, { "x": 1, "y": 1 }, { "x": 2, "y": 1 }, { "x": 2, "y": 2 }, { "x": 2, "y": 3 }, { "x": 3, "y": 3 }, { "x": 4, "y": 3 },
+  { "x": 4, "y": 4 }, { "x": 5, "y": 4 }, { "x": 5, "y": 5 }, { "x": 6, "y": 5 }, { "x": 6, "y": 6 }, { "x": 7, "y": 6 }, { "x": 7, "y": 7 }] },
+      
+      // Simulando resultado de Flood Fill
+    { estado_fsm: "FAST_RUN",    bateria_v: 7.10, posicao_x: 2, posicao_y: 4, orientacao: "SUL", erro_pid: 0.02, dist_frontal: 90, paredes: 14, rota_calculada: [
+  { "x": 0, "y": 0 }, { "x": 1, "y": 0 }, { "x": 1, "y": 1 }, { "x": 1, "y": 2 }, { "x": 2, "y": 2 }, { "x": 3, "y": 2 }, { "x": 4, "y": 2 }, { "x": 4, "y": 3 },
+  { "x": 4, "y": 4 }, { "x": 5, "y": 4 }, { "x": 6, "y": 4 }, { "x": 6, "y": 5 }, { "x": 6, "y": 6 }, { "x": 7, "y": 6 }, { "x": 7, "y": 7 }] }
+
     ]
   }
 ];


### PR DESCRIPTION
# Descrição

Este PR adiciona suporte à simulação da rota calculada durante o estado **FAST_RUN** no arquivo `src/backend/mock_sender.js`, permitindo que a equipe de Frontend desenvolva e teste a interface da funcionalidade de "Corrida Rápida" sem depender do robô físico.

## Alterações realizadas

* Localizado e atualizado o array `stream` utilizado pelo simulador.
* Adicionada a propriedade `rota_calculada` em todos os pacotes cujo `estado_fsm` é igual a `FAST_RUN`.
* Estruturada a rota como um array de objetos contendo coordenadas `x` e `y`, seguindo o formato esperado pelo frontend.
* Criadas rotas simuladas contínuas, partindo da origem `(0,0)` e seguindo em direção ao centro do labirinto.
* Mantida a compatibilidade com a serialização e transmissão dos pacotes UDP já existentes.
* Adição da dependência `detonov` ao `package.json` e `package-lock.json`. 

## Validação

* Executado `node src/backend/mock_sender.js`.
* Confirmado que o script continua funcionando normalmente.
* Confirmado que não houve erros de sintaxe após a inclusão da nova propriedade.
* Confirmado que os pacotes continuam sendo emitidos via UDP com as informações adicionais de rota.

## Objetivo

Disponibilizar dados simulados de navegação para que o Frontend possa implementar e validar a visualização da rota da Fast Run antes da integração com o algoritmo Flood Fill executado no robô real.
